### PR TITLE
lock version number of foundation-sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "css-loader": "^0.23.1",
     "expect": "^1.14.0",
-    "foundation-sites": "^6.2.0",
+    "foundation-sites": "6.2.0",
     "jquery": "^2.2.1",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.2",


### PR DESCRIPTION
Hello @andrewjmead I experienced an error when typed `wepback -w` at Lecture 87, with current code. I was going to open an issue, but I found I didn't see the error by this PR change. I hope there should be some change on this repository to make it with no errors.

```
ERROR in multi main
Module not found: Error: Cannot resolve module 'foundation-sites/dist/foundation.min.js' in ReactTodo
 @ multi main

ERROR in ./~/css-loader!./~/sass-loader!./app/styles/app.scss
Module build failed:
  $rgba: red($color), green($color), blue($color);
        ^
      Argument `$color` of `red($color)` must be a color

Backtrace:
	node_modules/foundation-sites/scss/util/_color.scss:19, in function `red`
	node_modules/foundation-sites/scss/util/_color.scss:19, in function `color-luminance`
	node_modules/foundation-sites/scss/util/_color.scss:44, in function `color-contrast`
	node_modules/foundation-sites/scss/util/_color.scss:63, in function `color-pick-contrast`
	node_modules/foundation-sites/scss/components/_badge.scss:59, in mixin `foundation-badge`
	node_modules/foundation-sites/scss/foundation.scss:84, in mixin `foundation-everything`
	stdin:6
      in ReactTodo/node_modules/foundation-sites/scss/util/_color.scss (line 19, column 10)
 @ ./~/style-loader!./~/css-loader!./~/sass-loader!./app/styles/app.scss 4:14-116
```